### PR TITLE
Enable libGL to be built against instead of just runtime swapped

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,11 @@ add_library(${GL} SHARED
 			$<TARGET_OBJECTS:ogldriver>
 			${DEF}
 			)
+install(TARGETS ${GL}
+	ARCHIVE DESTINATION lib
+	LIBRARY DESTINATION lib
+	RUNTIME DESTINATION bin
+)
 
 if(WIN32)
 	set_source_files_properties(${DEF} PROPERTIES GENERATED 1)

--- a/ogldriver/CMakeLists.txt
+++ b/ogldriver/CMakeLists.txt
@@ -85,3 +85,5 @@ add_library(ogldriver OBJECT fragff.cpp glfz.cpp glim.cpp
 	${CMAKE_CURRENT_BINARY_DIR}/glcl.cpp
 	${CMAKE_CURRENT_BINARY_DIR}/stubs.cpp)
 
+install(FILES gl/glext.h gl/gl.h gl/osmesa.h ${PLATFORM_HEADERS}
+	DESTINATION include/GL)

--- a/ogldriver/gl/gl.h
+++ b/ogldriver/gl/gl.h
@@ -2084,7 +2084,7 @@ typedef void (APIENTRYP PFNGLMULTITEXCOORD4SVARBPROC) (GLenum target, const GLsh
 
 #else  /* GL_GLEXT_LEGACY */
 
-#include <GL/glext.h>
+#include "glext.h"
 
 #endif  /* GL_GLEXT_LEGACY */
 

--- a/ogldriver/gl/glx.h
+++ b/ogldriver/gl/glx.h
@@ -3,7 +3,7 @@
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
-#include <gl/gl.h>
+#include "gl.h"
 
 #ifdef __cplusplus
 extern "C"

--- a/ogldriver/gl/glx.h
+++ b/ogldriver/gl/glx.h
@@ -189,6 +189,7 @@ void glXUseXFont(
 	int count,
 	int list);
 
+/* GLX 1.1 and later */
 const char* glXQueryExtensionsString(
 	Display* pDisplay,
 	int screen);
@@ -201,6 +202,105 @@ const char* glXQueryServerString(
 const char* glXGetClientString(
 	Display* pDisplay,
 	int name);
+
+/* GLX 1.2 and later */
+Display* glXGetCurrentDisplay();
+
+/* GLX 1.3 and later */
+GLXFBConfig* glXChooseFBConfig(
+	Display* pDisplay,
+	int screen,
+	const int* pAttribList,
+	int* ielements);
+
+int glXGetFBConfigAttrib(
+	Display* pDisplay,
+	GLXFBConfig config,
+	int attribute,
+	int* value);
+
+GLXFBConfig* glXGetFBConfigs(
+	Display* pDisplay,
+	int screen,
+	int* nelements);
+
+XVisualInfo* glXGetVisualFromFBConfig(
+	Display*dpy,
+	GLXFBConfig config);
+
+GLXWindow glXCreateWindow(
+	Display* pDisplay,
+	GLXFBConfig config,
+	Window win,
+	const int* pAttribList);
+
+void glXDestroyWindow(
+	Display* pDisplay,
+	GLXWindow window);
+
+GLXPixmap glXCreatePixmap(
+	Display* pDisplay,
+	GLXFBConfig config,
+	Pixmap pixmap,
+	const int* pAttribList);
+
+void glXDestroyPixmap(
+	Display* pDisplay,
+	GLXPixmap pixmap);
+
+GLXPbuffer glXCreatePbuffer(
+	Display* pDisplay,
+	GLXFBConfig config,
+	const int* pAttribList);
+
+void glXDestroyPbuffer(
+	Display* pDisplay,
+	GLXPbuffer pbuf);
+
+void glXQueryDrawable(
+	Display* pDisplay,
+	GLXDrawable draw,
+	int attribute,
+	unsigned int* value);
+
+GLXContext glXCreateNewContext(
+	Display* pDisplay,
+	GLXFBConfig config,
+	int renderType,
+	GLXContext shareList,
+	Bool direct);
+
+Bool glXMakeContextCurrent(
+	Display* pDisplay,
+	GLXDrawable draw,
+	GLXDrawable read,
+	GLXContext ctx);
+
+GLXDrawable glXGetCurrentReadDrawable();
+
+int glXQueryContext(
+	Display* pDisplay,
+	GLXContext ctx,
+	int attribute,
+	int* value);
+
+void glXSelectEvent(
+	Display* pDisplay,
+	GLXDrawable drawable,
+	unsigned long mask);
+
+void glXGetSelectedEvent(
+	Display* pDisplay,
+	GLXDrawable drawable,
+        unsigned long* mask);
+
+/* ARB 2. GLX_ARB_get_proc_address */
+void* glXGetProcAddressARB(
+	const GLubyte* procName);
+
+/* ARB 40. GLX_SGI_swap_control */
+int glXSwapIntervalSGI(
+	int interval);
 
 #ifdef __cplusplus
 } // end "C"

--- a/ogldriver/gl/osmesa.h
+++ b/ogldriver/gl/osmesa.h
@@ -57,7 +57,7 @@ extern "C" {
 #endif
 
 
-#include <GL/gl.h>
+#include "gl.h"
 
 
 #define OSMESA_MAJOR_VERSION 10

--- a/ogldriver/glx.cpp
+++ b/ogldriver/glx.cpp
@@ -411,7 +411,7 @@ extern "C" {
 void _glXResize(GLuint width, GLuint height);
 
 // @todo generate real FB configs
-GLXFBConfig *glXChooseFBConfig(Display *pDisplay, int screen, int *pAttribList, int *nelements)
+GLXFBConfig *glXChooseFBConfig(Display *pDisplay, int screen, const int *pAttribList, int *nelements)
 {
     MyGLXFBConfig *result = (MyGLXFBConfig *)Xmalloc(sizeof(MyGLXFBConfig));
     memcpy(result, &gFBConfig, sizeof(MyGLXFBConfig));
@@ -796,9 +796,9 @@ void glXDestroyPbuffer(Display *pDisplay, GLXPbuffer pixmap)
     return;
 }
 
-int glXQueryDrawable(Display *pDisplay, GLXDrawable draw, int attribute, unsigned int *value)
+void glXQueryDrawable(Display *pDisplay, GLXDrawable draw, int attribute, unsigned int *value)
 {
-    return Success;
+    return;
 }
 
 GLXDrawable glXGetCurrentReadDrawable()


### PR DESCRIPTION
A couple of fixes in order to get VTK to build against OpenSWR (vs runtime replacement):

* Create some install rules in the CMake files
* Add missing GLX exports to the appropriate includes
* Change two signatures to match the OpenGL spec

While without these, you can use OpenSWR as a drop-in runtime replacement for libGL, with these it be used as a stand alone OpenGL implementation, i.e. you can build against it without relying on an already existing implementation.